### PR TITLE
Improve betting demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.DS_Store
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
 # spt2
+
+This repository contains a demonstration of a data‑driven betting pipeline.
+
+## Usage
+
+Open `index.html` in a modern browser to experiment with the demo.
+You can either paste raw match text, load a JSON file, or fetch games from a
+local scraping server. Use the **Paste Matches** area to enter odds directly
+from a betting site, or select a file with the **Load Matches** button. The
+**Fetch Web Matches** option queries a server running `server.js` and then
+displays the parsed results. The analysis runs entirely in your browser with
+no external team lookups.
+
+### Starting the Scraping Server
+
+Install dependencies and run the server on port 3001:
+
+```bash
+npm install
+npm start
+```
+
+Then open `index.html` and click **Fetch Web Matches**.
+The server is configured to return mock data for offline testing.  To try
+scraping a real site such as **sports.bet9ja.com**, set the `BET9JA_URL`
+environment variable or edit `server.js` with your own HTML selectors and then
+restart the server.  If scraping fails the server automatically falls back to
+the mock matches so the demo keeps working offline.
+
+### Analysis Modes
+
+The drop-down menu lets you choose **Conservative**, **Balanced**, or **Aggressive** analysis. These modes adjust EV thresholds and confidence levels to match your risk appetite.
+
+## Framework Highlights (May 2025)
+
+- Singles require EV of at least **+10%**, while system legs need **+2%**.
+- Bankroll allocation defaults to **40% singles** and **60% systems**.
+- Staking uses half-Kelly sizing capped at **5%** of bankroll per bet.
+
+## Disclaimer
+
+The included tools are for educational purposes only. Please gamble
+responsibly and at your own risk.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,786 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Data-Driven Betting Pipeline</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: linear-gradient(135deg, #1e3c72, #2a5298, #3b82f6);
+            min-height: 100vh;
+            color: #ffffff;
+            padding: 20px;
+        }
+        .container {
+            max-width: 1400px;
+            margin: 0 auto;
+            background: rgba(255, 255, 255, 0.1);
+            backdrop-filter: blur(10px);
+            border-radius: 20px;
+            padding: 30px;
+            box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+        }
+        .header {
+            text-align: center;
+            margin-bottom: 40px;
+            padding-bottom: 20px;
+            border-bottom: 2px solid rgba(255, 255, 255, 0.2);
+        }
+        .header h1 {
+            font-size: 2.5rem;
+            margin-bottom: 10px;
+            background: linear-gradient(45deg, #ffd700, #ffed4e);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+        .controls {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 20px;
+            margin-bottom: 30px;
+        }
+        .control-group {
+            background: rgba(255, 255, 255, 0.1);
+            padding: 20px;
+            border-radius: 12px;
+            border: 1px solid rgba(255, 255, 255, 0.2);
+        }
+        .control-group h3 {
+            margin-bottom: 15px;
+            color: #ffd700;
+            font-size: 1.1rem;
+        }
+        .input-group {
+            margin-bottom: 15px;
+        }
+        .input-group label {
+            display: block;
+            margin-bottom: 5px;
+            font-size: 0.9rem;
+            color: #e2e8f0;
+        }
+        .input-group input, .input-group select {
+            width: 100%;
+            padding: 10px;
+            border: none;
+            border-radius: 8px;
+            background: rgba(255, 255, 255, 0.1);
+            color: #ffffff;
+            font-size: 0.9rem;
+            border: 1px solid rgba(255, 255, 255, 0.3);
+        }
+        .input-group input:focus, .input-group select:focus {
+            outline: none;
+            border-color: #ffd700;
+            box-shadow: 0 0 10px rgba(255, 215, 0, 0.3);
+        }
+        .btn {
+            background: linear-gradient(45deg, #00c851, #28a745);
+            color: white;
+            border: none;
+            padding: 15px 30px;
+            border-radius: 10px;
+            font-size: 1rem;
+            font-weight: bold;
+            cursor: pointer;
+            transition: all 0.3s ease;
+            box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
+        }
+        .btn:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 8px 25px rgba(0, 0, 0, 0.3);
+        }
+        .results {
+            margin-top: 30px;
+        }
+        .match-analysis {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 12px;
+            padding: 20px;
+            margin-bottom: 20px;
+            border: 1px solid rgba(255, 255, 255, 0.2);
+        }
+        .match-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 15px;
+            padding-bottom: 10px;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+        }
+        .match-teams {
+            font-size: 1.2rem;
+            font-weight: bold;
+        }
+        .match-time {
+            background: rgba(255, 215, 0, 0.2);
+            padding: 5px 10px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+        }
+        .analysis-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 15px;
+            margin-bottom: 20px;
+        }
+        .metric {
+            background: rgba(255, 255, 255, 0.05);
+            padding: 15px;
+            border-radius: 8px;
+            text-align: center;
+        }
+        .metric-label {
+            font-size: 0.8rem;
+            color: #cbd5e0;
+            margin-bottom: 5px;
+        }
+        .metric-value {
+            font-size: 1.1rem;
+            font-weight: bold;
+            color: #ffffff;
+        }
+        .recommendation {
+            background: linear-gradient(45deg, #667eea, #764ba2);
+            padding: 20px;
+            border-radius: 12px;
+            margin-top: 15px;
+        }
+        .rec-high-ev { background: linear-gradient(45deg, #00c851, #28a745); }
+        .rec-medium-ev { background: linear-gradient(45deg, #ff8f00, #ff6f00); }
+        .rec-no-bet { background: linear-gradient(45deg, #d32f2f, #b71c1c); }
+        .recommendation h4 { margin-bottom: 10px; font-size: 1.1rem; }
+        .bet-details {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+            gap: 10px;
+            margin-top: 10px;
+        }
+        .bet-detail {
+            text-align: center;
+            padding: 8px;
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 6px;
+        }
+        .portfolio-summary {
+            background: rgba(255, 255, 255, 0.1);
+            padding: 25px;
+            border-radius: 15px;
+            margin-top: 30px;
+            border: 2px solid rgba(255, 215, 0, 0.3);
+        }
+        .portfolio-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+            gap: 20px;
+            margin-top: 15px;
+        }
+        .portfolio-item {
+            text-align: center;
+            padding: 15px;
+            background: rgba(255, 255, 255, 0.05);
+            border-radius: 10px;
+        }
+        .portfolio-value {
+            font-size: 1.5rem;
+            font-weight: bold;
+            color: #ffd700;
+            margin-bottom: 5px;
+        }
+        .loading {
+            text-align: center;
+            padding: 40px;
+            font-size: 1.2rem;
+            color: #ffd700;
+        }
+        .spinner {
+            border: 3px solid rgba(255, 255, 255, 0.3);
+            border-top: 3px solid #ffd700;
+            border-radius: 50%;
+            width: 40px;
+            height: 40px;
+            animation: spin 1s linear infinite;
+            margin: 0 auto 20px;
+        }
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+        .hidden { display: none; }
+        option { background: #2a5298; color: white; }
+        .disclaimer {
+            text-align: center;
+            font-size: 0.8rem;
+            color: #e2e8f0;
+            margin-top: 40px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>🎯 Data-Driven Betting Pipeline</h1>
+            <p>Advanced EV+ Selection System | May 2025 Framework</p>
+        </div>
+        <div class="controls">
+            <div class="control-group">
+                <h3>⚙️ System Parameters</h3>
+                <div class="input-group">
+                    <label>Current Bankroll ($)</label>
+                    <input type="number" id="bankroll" value="10000" min="100">
+                </div>
+                <div class="input-group">
+                    <label>Singles EV Threshold (%)</label>
+                    <input type="number" id="singlesEV" value="10" step="0.1" min="0">
+                </div>
+                <div class="input-group">
+                    <label>System EV Threshold (%)</label>
+                    <input type="number" id="systemEV" value="2" step="0.1" min="0">
+                </div>
+            </div>
+            <div class="control-group">
+                <h3>📊 Model Settings</h3>
+                <div class="input-group">
+                    <label>Confidence Threshold</label>
+                    <input type="number" id="confidence" value="0.65" step="0.01" min="0" max="1">
+                </div>
+                <div class="input-group">
+                    <label>Kelly Fraction</label>
+                    <input type="number" id="kellyFraction" value="0.5" step="0.1" min="0.1" max="1">
+                </div>
+                <div class="input-group">
+                    <label>Max Stake per Bet (%)</label>
+                    <input type="number" id="maxStake" value="5" step="0.5" min="0.5" max="10">
+                </div>
+            </div>
+            <div class="control-group">
+                <h3>🎲 Portfolio Allocation</h3>
+                <div class="input-group">
+                    <label>Singles Pool (%)</label>
+                    <input type="number" id="singlesAllocation" value="40" min="0" max="100">
+                </div>
+                <div class="input-group">
+                    <label>Systems Pool (%)</label>
+                    <input type="number" id="systemsAllocation" value="60" min="0" max="100">
+                </div>
+                <div class="input-group">
+                    <label>Analysis Mode</label>
+                    <select id="analysisMode">
+                        <option value="conservative">Conservative</option>
+                        <option value="balanced" selected>Balanced</option>
+                        <option value="aggressive">Aggressive</option>
+                    </select>
+                </div>
+            </div>
+        </div>
+        <div class="control-group" style="margin-top:20px;">
+            <h3>📋 Paste Matches</h3>
+            <textarea id="matchesText" rows="10" placeholder="Paste odds table text here" style="width:100%; padding:10px; border-radius:8px; background:rgba(255,255,255,0.1); color:#fff; border:1px solid rgba(255,255,255,0.3);"></textarea>
+            <div style="margin-top:10px;">
+                <input type="file" id="matchesFile" accept="application/json">
+                <button class="btn" onclick="loadTodaysMatches()" style="margin-left:10px;background:linear-gradient(45deg,#2196f3,#1976d2);">📅 Load Matches</button>
+                <button class="btn" onclick="fetchMatchesFromWeb()" style="margin-left:10px;background:linear-gradient(45deg,#ff7043,#f4511e);">🔎 Fetch Web Matches</button>
+            </div>
+        </div>
+        <div style="text-align: center; margin: 20px 0 30px;">
+            <button class="btn" onclick="runAnalysis()">🚀 Analyze Pasted Matches</button>
+        </div>
+        <div id="loading" class="loading hidden">
+            <div class="spinner"></div>
+            <p>Analyzing matches and calculating optimal selections...</p>
+        </div>
+        <div id="results" class="results"></div>
+        <div id="portfolio" class="portfolio-summary hidden">
+            <h3 style="text-align: center; margin-bottom: 20px; color: #ffd700;">📈 Portfolio Summary</h3>
+            <div class="portfolio-grid">
+                <div class="portfolio-item">
+                    <div class="portfolio-value" id="totalStake">$0</div>
+                    <div>Total Stake</div>
+                </div>
+                <div class="portfolio-item">
+                    <div class="portfolio-value" id="expectedReturn">$0</div>
+                    <div>Expected Return</div>
+                </div>
+                <div class="portfolio-item">
+                    <div class="portfolio-value" id="totalEV">0%</div>
+                    <div>Portfolio EV</div>
+                </div>
+                <div class="portfolio-item">
+                    <div class="portfolio-value" id="singlesCount">0</div>
+                    <div>Singles Bets</div>
+                </div>
+                <div class="portfolio-item">
+                    <div class="portfolio-value" id="systemsCount">0</div>
+                    <div>System Legs</div>
+                </div>
+                <div class="portfolio-item">
+                    <div class="portfolio-value" id="riskLevel">Low</div>
+                    <div>Risk Level</div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <script>
+        class BettingFramework {
+            constructor() {
+                this.matches = [];
+                this.parameters = this.getParameters();
+                this.applyAnalysisMode();
+                this.initializeTeamRatings();
+                this.performanceHistory = [];
+            }
+            getParameters() {
+                return {
+                    bankroll: parseFloat(document.getElementById('bankroll').value),
+                    singlesEV: parseFloat(document.getElementById('singlesEV').value) / 100,
+                    systemEV: parseFloat(document.getElementById('systemEV').value) / 100,
+                    confidence: parseFloat(document.getElementById('confidence').value),
+                    kellyFraction: parseFloat(document.getElementById('kellyFraction').value),
+                    maxStake: parseFloat(document.getElementById('maxStake').value) / 100,
+                    singlesAllocation: parseFloat(document.getElementById('singlesAllocation').value) / 100,
+                    systemsAllocation: parseFloat(document.getElementById('systemsAllocation').value) / 100,
+                    analysisMode: document.getElementById('analysisMode').value
+                };
+            }
+            applyAnalysisMode() {
+                if (this.parameters.analysisMode === 'conservative') {
+                    this.parameters.singlesEV += 0.05;
+                    this.parameters.systemEV += 0.02;
+                    this.parameters.confidence += 0.05;
+                } else if (this.parameters.analysisMode === 'aggressive') {
+                    this.parameters.singlesEV = Math.max(0, this.parameters.singlesEV - 0.05);
+                    this.parameters.systemEV = Math.max(0, this.parameters.systemEV - 0.02);
+                    this.parameters.confidence = Math.max(0, this.parameters.confidence - 0.05);
+                }
+            }
+            initializeTeamRatings() {
+                this.teamData = {
+                    'Botswana': { elo: 1420, form: 0.6, homeAdvantage: 0.15, injuries: 0.05, attackRating: 1.2, defenseRating: 1.3 },
+                    'Zambia': { elo: 1480, form: 0.75, homeAdvantage: 0, injuries: 0.02, attackRating: 1.4, defenseRating: 1.1 },
+                    'Eswatini': { elo: 1380, form: 0.5, homeAdvantage: 0.15, injuries: 0.08, attackRating: 1.0, defenseRating: 1.4 },
+                    'Tanzania': { elo: 1520, form: 0.8, homeAdvantage: 0, injuries: 0.03, attackRating: 1.5, defenseRating: 1.0 },
+                    'Orbit College FC': { elo: 1450, form: 0.65, homeAdvantage: 0.12, injuries: 0.04, attackRating: 1.2, defenseRating: 1.2 },
+                    'Casric Stars FC': { elo: 1440, form: 0.6, homeAdvantage: 0, injuries: 0.06, attackRating: 1.1, defenseRating: 1.3 },
+                    'FC Olimpik': { elo: 1480, form: 0.7, homeAdvantage: 0.15, injuries: 0.03, attackRating: 1.3, defenseRating: 1.0 },
+                    'Pfk Aral': { elo: 1520, form: 0.75, homeAdvantage: 0, injuries: 0.02, attackRating: 1.6, defenseRating: 0.9 },
+                    'Znk Hajduk Split': { elo: 1380, form: 0.4, homeAdvantage: 0.12, injuries: 0.08, attackRating: 0.8, defenseRating: 1.6 },
+                    'Znk Agram': { elo: 1620, form: 0.85, homeAdvantage: 0, injuries: 0.02, attackRating: 1.7, defenseRating: 0.8 },
+                    'Gimnasia de Mendoza Reserve': { elo: 1680, form: 0.9, homeAdvantage: 0.15, injuries: 0.01, attackRating: 1.8, defenseRating: 0.7 },
+                    'Defensores Unidos Reserve': { elo: 1320, form: 0.3, homeAdvantage: 0, injuries: 0.12, attackRating: 0.6, defenseRating: 1.8 },
+                    'Sportive de Douala': { elo: 1350, form: 0.45, homeAdvantage: 0.15, injuries: 0.07, attackRating: 0.9, defenseRating: 1.5 },
+                    'Fauve Azur de Yaounde': { elo: 1580, form: 0.8, homeAdvantage: 0, injuries: 0.03, attackRating: 1.6, defenseRating: 0.9 },
+                    'Haka': { elo: 1450, form: 0.65, homeAdvantage: 0.12, injuries: 0.04, attackRating: 1.2, defenseRating: 1.2 },
+                    'Gnistan': { elo: 1420, form: 0.6, homeAdvantage: 0, injuries: 0.06, attackRating: 1.1, defenseRating: 1.3 },
+                    'OLS Oulu': { elo: 1380, form: 0.5, homeAdvantage: 0.12, injuries: 0.08, attackRating: 0.9, defenseRating: 1.4 },
+                    'EIF': { elo: 1580, form: 0.8, homeAdvantage: 0, injuries: 0.03, attackRating: 1.6, defenseRating: 0.9 },
+                    'Podhale Nowy Targ': { elo: 1520, form: 0.7, homeAdvantage: 0.15, injuries: 0.04, attackRating: 1.4, defenseRating: 1.1 },
+                'Legia Warszawa II': { elo: 1480, form: 0.65, homeAdvantage: 0, injuries: 0.05, attackRating: 1.3, defenseRating: 1.2 }
+                };
+            }
+
+            updateTeamRatings(match, result){
+                const K = 32;
+                const expected = this.calculateTrueProbability(match.home, match.away).home;
+                const actualHome = result === 'home' ? 1 : result === 'draw' ? 0.5 : 0;
+                if(this.teamData[match.home]){
+                    this.teamData[match.home].elo += K * (actualHome - expected);
+                }
+                if(this.teamData[match.away]){
+                    this.teamData[match.away].elo += K * ((1 - actualHome) - (1 - expected));
+                }
+            }
+
+            trackPerformance(selections, results){
+                const performance = {
+                    timestamp: Date.now(),
+                    selections: selections.length,
+                    wins: results.filter(r => r.won).length,
+                    totalStake: selections.reduce((s,b) => s + b.stake, 0),
+                    totalReturn: results.reduce((s,r) => s + (r.won ? r.payout : 0), 0)
+                };
+                this.performanceHistory.push(performance);
+            }
+            calculateExpectedGoals(homeTeam, awayTeam) {
+                const homeData = this.teamData[homeTeam] || { attackRating: 1.2, defenseRating: 1.2 };
+                const awayData = this.teamData[awayTeam] || { attackRating: 1.2, defenseRating: 1.2 };
+                const homeGoals = 1.3 * homeData.attackRating * awayData.defenseRating;
+                const awayGoals = 1.1 * awayData.attackRating * homeData.defenseRating;
+                const totalGoals = homeGoals + awayGoals;
+                return { homeGoals, awayGoals, totalGoals };
+            }
+            calculateOverUnderProbability(totalExpectedGoals, line) {
+                const lambda = totalExpectedGoals;
+                if (line % 1 === 0.5) {
+                    const whole = Math.floor(line);
+                    let probUnder = 0;
+                    for(let i=0;i<=whole;i++){
+                        probUnder += Math.exp(-lambda) * Math.pow(lambda, i) / this.factorial(i);
+                    }
+                    return { over: 1 - probUnder, under: probUnder };
+                }
+                let probUnder = 0;
+                for(let i=0;i<=line;i++){
+                    probUnder += Math.exp(-lambda) * Math.pow(lambda, i) / this.factorial(i);
+                }
+                return { over: 1 - probUnder, under: probUnder };
+            }
+            poissonCDF(k, lambda) {
+                let sum = 0;
+                for (let i = 0; i <= k; i++) {
+                    sum += Math.exp(-lambda) * Math.pow(lambda, i) / this.factorial(i);
+                }
+                return sum;
+            }
+            factorial(n) {
+                if (n <= 1) return 1;
+                let result = 1;
+                for (let i = 2; i <= n; i++) {
+                    result *= i;
+                }
+                return result;
+            }
+            calculateTrueProbability(homeTeam, awayTeam) {
+                const homeData = this.teamData[homeTeam] || { elo: 1500, form: 0.5, homeAdvantage: 0.1, injuries: 0.05 };
+                const awayData = this.teamData[awayTeam] || { elo: 1500, form: 0.5, homeAdvantage: 0, injuries: 0.05 };
+                const eloDiff = homeData.elo - awayData.elo;
+                const formDiff = homeData.form - awayData.form;
+                const homeAdv = homeData.homeAdvantage;
+                const injuryPenalty = homeData.injuries - awayData.injuries;
+                const alpha = 0.003;
+                const beta = 0.4;
+                const gamma = 0.3;
+                const logit = alpha * eloDiff + beta * homeAdv + gamma * (formDiff - injuryPenalty);
+                const probHome = 1 / (1 + Math.exp(-logit));
+                const probDraw = 0.25 + 0.1 * Math.random();
+                const probAway = 1 - probHome - probDraw;
+                return {
+                    home: Math.max(0.05, Math.min(0.90, probHome)),
+                    draw: Math.max(0.15, Math.min(0.40, probDraw)),
+                    away: Math.max(0.05, Math.min(0.90, probAway))
+                };
+            }
+            calculateEV(p, odds) { return odds <= 1 ? -1 : p * (odds - 1) - (1 - p); }
+            calculateKellyStake(p, odds, bankroll) {
+                if (!odds || odds <= 1) return 0;
+                const b = odds - 1;
+                const q = 1 - p;
+                const kelly = (p * b - q) / b;
+                const adj = kelly * this.parameters.kellyFraction;
+                const stake = Math.max(0, adj * bankroll);
+                return Math.min(stake, bankroll * this.parameters.maxStake);
+            }
+            getConfidenceScore(homeTeam, awayTeam, marketType) {
+                const homeData = this.teamData[homeTeam] || { elo: 1500, form: 0.5, injuries: 0.05 };
+                const awayData = this.teamData[awayTeam] || { elo: 1500, form: 0.5, injuries: 0.05 };
+                const eloDiff = Math.abs(homeData.elo - awayData.elo);
+                const formStability = Math.min(homeData.form, awayData.form);
+                const injuryImpact = Math.max(homeData.injuries, awayData.injuries);
+                let baseConfidence = 0.5 + (eloDiff / 1500) + (formStability * 0.3) - (injuryImpact * 2);
+                const marketMultipliers = {
+                    "1": 0.95,
+                    "X": 0.85,
+                    "2": 0.95,
+                    "1X": 1.05,
+                    "12": 1.1,
+                    "X2": 1.05,
+                    "Over": 0.9,
+                    "Under": 0.9
+                };
+                baseConfidence *= (marketMultipliers[marketType] || 1.0);
+                return Math.min(0.95, Math.max(0.3, baseConfidence));
+            }
+            createErrorAnalysis(match, error){
+                return {
+                    match: `${match.home || '?'} vs ${match.away || '?'}`,
+                    time: match.time || '',
+                    error: error.message,
+                    markets: []
+                };
+            }
+
+            analyzeMatch(match) {
+                try {
+                    if(!match || !match.home || !match.away || !match.odds){
+                        throw new Error('Invalid match data');
+                    }
+                    const { home, away, odds, time } = match;
+                    const trueProb = this.calculateTrueProbability(home, away);
+                    const expected = this.calculateExpectedGoals(home, away);
+                    const ou = this.calculateOverUnderProbability(expected.totalGoals, odds.goals);
+                const markets = [
+                    { name: 'Home Win (1)', probability: trueProb.home, odds: odds.home, type: '1' },
+                    { name: 'Draw (X)', probability: trueProb.draw, odds: odds.draw, type: 'X' },
+                    { name: 'Away Win (2)', probability: trueProb.away, odds: odds.away, type: '2' },
+                    { name: 'Home/Draw (1X)', probability: trueProb.home + trueProb.draw, odds: odds.homeX, type: '1X' },
+                    { name: 'Home/Away (12)', probability: trueProb.home + trueProb.away, odds: odds.homeAway, type: '12' },
+                    { name: 'Draw/Away (X2)', probability: trueProb.draw + trueProb.away, odds: odds.drawAway, type: 'X2' },
+                    { name: `Over ${odds.goals}`, probability: ou.over, odds: odds.over, type: 'Over' },
+                    { name: `Under ${odds.goals}`, probability: ou.under, odds: odds.under, type: 'Under' }
+                ];
+                    const analysis = { match: `${home} vs ${away}`, time, expectedGoals: expected, markets: [] };
+                for (const m of markets) {
+                    if (!m.odds || m.odds <= 1) continue;
+                    const ev = this.calculateEV(m.probability, m.odds);
+                    const conf = this.getConfidenceScore(home, away, m.type);
+                    const adjustedEV = ev * conf;
+                    const stake = this.calculateKellyStake(m.probability, m.odds, this.parameters.bankroll);
+                    analysis.markets.push({
+                        name: m.name,
+                        type: m.type,
+                        probability: m.probability,
+                        impliedProbability: 1 / m.odds,
+                        odds: m.odds,
+                        ev,
+                        adjustedEV,
+                        confidence: conf,
+                        stake,
+                        expectedReturn: stake * m.odds * m.probability
+                    });
+                }
+                    return analysis;
+                } catch(error){
+                    console.error('Match analysis failed:', error.message);
+                    return this.createErrorAnalysis(match, error);
+                }
+            }
+            filterSelections(analyses) {
+                const singles = [];
+                const systemLegs = [];
+                for (const a of analyses) {
+                    for (const m of a.markets) {
+                        const systemOk = m.adjustedEV >= this.parameters.systemEV && m.confidence >= this.parameters.confidence;
+                        const singleOk = m.adjustedEV >= this.parameters.singlesEV && m.confidence >= this.parameters.confidence + 0.1;
+                        if (singleOk) singles.push({ ...m, match: a.match, time: a.time, category: 'single' });
+                        else if (systemOk) systemLegs.push({ ...m, match: a.match, time: a.time, category: 'system' });
+                    }
+                }
+                singles.sort((a,b)=>b.adjustedEV-a.adjustedEV);
+                systemLegs.sort((a,b)=>b.adjustedEV-a.adjustedEV);
+                return { singles: singles.slice(0,7), systemLegs: systemLegs.slice(0,10) };
+            }
+            applyAllocation(selections){
+                const singlesBudget=this.parameters.bankroll*this.parameters.singlesAllocation;
+                const systemsBudget=this.parameters.bankroll*this.parameters.systemsAllocation;
+                const singlesTotal=selections.singles.reduce((s,b)=>s+b.stake,0);
+                if(singlesTotal>singlesBudget){
+                    const f=singlesBudget/singlesTotal;
+                    selections.singles.forEach(b=>{
+                        b.stake*=f;
+                        b.expectedReturn=b.stake*b.odds*b.probability;
+                    });
+                }
+                const systemsTotal=selections.systemLegs.reduce((s,b)=>s+b.stake,0);
+                if(systemsTotal>systemsBudget){
+                    const f=systemsBudget/systemsTotal;
+                    selections.systemLegs.forEach(b=>{
+                        b.stake*=f;
+                        b.expectedReturn=b.stake*b.odds*b.probability;
+                    });
+                }
+                return selections;
+            }
+            calculatePortfolioMetrics(selections) {
+                const singlesStake = selections.singles.reduce((sum, b)=>sum+b.stake,0);
+                const systemsStake = selections.systemLegs.reduce((sum,b)=>sum+b.stake,0);
+                const totalStake = singlesStake + systemsStake;
+                const singlesReturn = selections.singles.reduce((sum,b)=>sum+b.expectedReturn,0);
+                const systemsReturn = selections.systemLegs.reduce((sum,b)=>sum+(b.stake*b.odds*b.probability),0);
+                const expectedReturn = singlesReturn + systemsReturn;
+                const portfolioEV = totalStake>0 ? (expectedReturn-totalStake)/totalStake : 0;
+                let riskLevel = 'Low';
+                if (portfolioEV>0.15) riskLevel='High';
+                else if (portfolioEV>0.08) riskLevel='Medium';
+                return { totalStake, expectedReturn, portfolioEV, singlesCount: selections.singles.length, systemsCount: selections.systemLegs.length, riskLevel };
+            }
+            analyzeMatches(matches){
+                const analyses = matches.map(m=>this.analyzeMatch(m));
+                let selections = this.filterSelections(analyses);
+                selections = this.applyAllocation(selections);
+                const portfolio = this.calculatePortfolioMetrics(selections);
+                return { analyses, selections, portfolio };
+            }
+        }
+        function mockMatches(){
+            return [
+                { home:'Botswana', away:'Zambia', time:'12:00', odds:{ home:2.8, draw:3.1, away:2.4, homeX:1.6, homeAway:1.4, drawAway:1.6, goals:2.5, over:1.9, under:1.9 } },
+                { home:'Haka', away:'Gnistan', time:'16:00', odds:{ home:1.8, draw:3.3, away:4.0, homeX:1.3, homeAway:1.2, drawAway:2.0, goals:2.5, over:1.8, under:2.0 } }
+            ];
+        }
+        function displayResults(result){
+            const res = document.getElementById('results');
+            res.innerHTML='';
+            for(const a of result.analyses){
+                const div=document.createElement('div');
+                div.className='match-analysis';
+                const header=document.createElement('div');
+                header.className='match-header';
+                header.innerHTML=`<div class="match-teams">${a.match}</div><div class="match-time">${a.time}</div>`;
+                div.appendChild(header);
+                const grid=document.createElement('div');
+                grid.className='analysis-grid';
+                const metrics=[
+                    {label:'Home Win', value:(a.markets[0].probability*100).toFixed(1)+'%'},
+                    {label:'Draw', value:(a.markets[1].probability*100).toFixed(1)+'%'},
+                    {label:'Away Win', value:(a.markets[2].probability*100).toFixed(1)+'%'},
+                    {label:'Total Goals', value:a.expectedGoals.totalGoals.toFixed(2)}
+                ];
+                for(const m of metrics){
+                    const md=document.createElement('div');
+                    md.className='metric';
+                    md.innerHTML=`<div class="metric-label">${m.label}</div><div class="metric-value">${m.value}</div>`;
+                    grid.appendChild(md);
+                }
+                div.appendChild(grid);
+                res.appendChild(div);
+            }
+            const port=document.getElementById('portfolio');
+            port.classList.remove('hidden');
+            document.getElementById('totalStake').innerText='$'+result.portfolio.totalStake.toFixed(2);
+            document.getElementById('expectedReturn').innerText='$'+result.portfolio.expectedReturn.toFixed(2);
+            document.getElementById('totalEV').innerText=(result.portfolio.portfolioEV*100).toFixed(2)+'%';
+            document.getElementById('singlesCount').innerText=result.portfolio.singlesCount;
+            document.getElementById('systemsCount').innerText=result.portfolio.systemsCount;
+            document.getElementById('riskLevel').innerText=result.portfolio.riskLevel;
+        }
+        function parseMatchesFromText(text){
+            try {
+                const lines=text.split(/\n/).map(l=>l.trim()).filter(l=>l);
+                const matches=[];
+                for(let i=0;i<lines.length;i++){
+                    const timeMatch=lines[i].match(/^(\d{1,2}:\d{2})/);
+                    if(timeMatch){
+                        const time=timeMatch[1];
+                        const window=lines.slice(i+1,i+12);
+                        const teams=window.filter(l=>!/^\d+\.?\d*$/.test(l)&&l.length>2).slice(0,2);
+                        const odds=window.filter(l=>/^\d+\.?\d*$/.test(l)).map(parseFloat).slice(0,9);
+                        if(teams.length>=2&&odds.length>=6){
+                            const [home,away]=teams;
+                            const [homeOdd,drawOdd,awayOdd,homeX,homeAway,drawAway,goals,over,under]=odds;
+                            matches.push({
+                                home:home.replace(/[^\w\s]/g,'').trim(),
+                                away:away.replace(/[^\w\s]/g,'').trim(),
+                                time,
+                                odds:{
+                                    home:homeOdd||2,
+                                    draw:drawOdd||3,
+                                    away:awayOdd||3,
+                                    homeX:homeX||1.3,
+                                    homeAway:homeAway||1.3,
+                                    drawAway:drawAway||1.6,
+                                    goals:goals||2.5,
+                                    over:over||1.8,
+                                    under:under||1.9
+                                }
+                            });
+                        }
+                    }
+                }
+                return matches;
+            } catch(err){
+                console.error('Parse error:',err);
+                return [];
+            }
+        }
+
+        function validateMatchData(match){
+            const errors=[];
+            if(!match.home||typeof match.home!=='string') errors.push('Invalid home team');
+            if(!match.away||typeof match.away!=='string') errors.push('Invalid away team');
+            if(!match.odds||typeof match.odds!=='object') errors.push('Missing odds');
+            if(match.odds){
+                for(const [m,o] of Object.entries(match.odds)){
+                    if(typeof o!=='number'||o<1.01||o>100) errors.push(`Invalid ${m} odds: ${o}`);
+                }
+            }
+            return errors;
+        }
+
+        async function runAnalysis(){
+            document.getElementById('loading').classList.remove('hidden');
+            try{
+                const text=document.getElementById('matchesText').value;
+                let matches=parseMatchesFromText(text);
+                matches = matches.filter(m=>validateMatchData(m).length===0);
+                const framework=new BettingFramework();
+                const result=framework.analyzeMatches(matches);
+                displayResults(result);
+            }catch(err){
+                alert('Analysis failed: '+err.message);
+            }finally{
+                document.getElementById('loading').classList.add('hidden');
+            }
+        }
+
+        async function loadTodaysMatches(){
+            const input=document.getElementById('matchesFile');
+            if(!input.files.length){
+                alert('Please select a JSON file with matches');
+                return;
+            }
+            document.getElementById('loading').classList.remove('hidden');
+            try{
+                const text=await input.files[0].text();
+                const matches=JSON.parse(text);
+                const valid=matches.filter(m=>validateMatchData(m).length===0);
+                const framework=new BettingFramework();
+                const result=framework.analyzeMatches(valid);
+                displayResults(result);
+            }catch(err){
+                alert('Failed to load matches: '+err.message);
+            }finally{
+                document.getElementById('loading').classList.add('hidden');
+            }
+        }
+
+        async function fetchMatchesFromWeb(){
+            const url='http://127.0.0.1:3001/scrape';
+            document.getElementById('loading').classList.remove('hidden');
+            try{
+                const res=await fetch(url);
+                const data=await res.json();
+                if(!data.matches){
+                    throw new Error('No matches returned');
+                }
+                const matches=data.matches.map(m=>{
+                    const [home,away]=m.match.split(' vs ');
+                    const mk=m.markets;
+                    return {
+                        home: home || '',
+                        away: away || '',
+                        time: m.time || '',
+                        odds: {
+                            home: mk['1'],
+                            draw: mk['X'],
+                            away: mk['2'],
+                            homeX: mk['1X'],
+                            homeAway: mk['12'],
+                            drawAway: mk['X2'],
+                            goals: 2.5,
+                            over: mk['Over 2.5'],
+                            under: mk['Under 2.5']
+                        }
+                    };
+                });
+                const valid=matches.filter(m=>validateMatchData(m).length===0);
+                const framework=new BettingFramework();
+                const result=framework.analyzeMatches(valid);
+                displayResults(result);
+            }catch(err){
+                alert('Error fetching matches: '+err.message);
+            }finally{
+                document.getElementById('loading').classList.add('hidden');
+            }
+        }
+    </script>
+    <footer class="disclaimer">
+        <p>All data is for informational purposes only. Please gamble responsibly.</p>
+    </footer>
+</body>
+</html>

--- a/matches.json
+++ b/matches.json
@@ -1,0 +1,14 @@
+[
+  {
+    "home": "Botswana",
+    "away": "Zambia",
+    "time": "12:00",
+    "odds": {"home": 2.8, "draw": 3.1, "away": 2.4, "homeX": 1.6, "homeAway": 1.4, "drawAway": 1.6, "goals": 2.5, "over": 1.9, "under": 1.9 }
+  },
+  {
+    "home": "Haka",
+    "away": "Gnistan",
+    "time": "16:00",
+    "odds": {"home": 1.8, "draw": 3.3, "away": 4.0, "homeX": 1.3, "homeAway": 1.2, "drawAway": 2.0, "goals": 2.5, "over": 1.8, "under": 2.0 }
+  }
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1259 @@
+{
+  "name": "spt2",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "spt2",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "axios": "^1.5.0",
+        "cheerio": "^1.1.0",
+        "cors": "^2.8.5",
+        "express": "^5.1.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.0.tgz",
+      "integrity": "sha512-+0hMx9eYhJvWbgpKV9hN7jg0JcwydpopZE4hgi+KvQtByZXPp04NiCWU0LzcAbP63abZckIHkTQaXVF52mX3xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.0",
+        "htmlparser2": "^10.0.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.10.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18.17"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.6.3",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.10.0.tgz",
+      "integrity": "sha512-u5otvFBOBZvmdjWLVW+5DAc9Nkq8f24g0O9oY7qw2JVIF1VocIFoyz9JFkuVOS2j41AufeO0xnlweJ2RLT8nGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "spt2",
+  "version": "1.0.0",
+  "description": "This repository contains a demonstration of a data‑driven betting pipeline.",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "axios": "^1.5.0",
+    "cheerio": "^1.1.0",
+    "cors": "^2.8.5",
+    "express": "^5.1.0"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,94 @@
+const express = require('express');
+const cors = require('cors');
+const axios = require('axios');
+const cheerio = require('cheerio');
+
+const app = express();
+
+app.use(cors({
+    origin: ['http://127.0.0.1:5500', 'http://localhost:5500'],
+    methods: ['GET', 'POST'],
+    allowedHeaders: ['Content-Type']
+}));
+
+app.get('/health', (req, res) => {
+    res.json({
+        status: '✅ Server running successfully',
+        timestamp: new Date().toISOString(),
+        port: 3001,
+        frontendUrl: 'http://127.0.0.1:5500'
+    });
+});
+
+async function fetchBet9jaMatches() {
+    const target = process.env.BET9JA_URL || 'https://sports.bet9ja.com/';
+    try {
+        const response = await axios.get(target);
+        const $ = cheerio.load(response.data);
+        const matches = [];
+        $("[data-fixture]").each((_, el) => {
+            const teams = $(el).find('.fixturedetail').text().trim();
+            const time = $(el).find('.fixturetime').text().trim();
+            const odds = {};
+            $(el).find('[data-selection]').each((__, btn) => {
+                const sel = $(btn).attr('data-selection');
+                const price = parseFloat($(btn).text());
+                if (!isNaN(price)) odds[sel] = price;
+            });
+            if (teams) {
+                matches.push({ match: teams, time, markets: odds });
+            }
+        });
+        return matches;
+    } catch (err) {
+        console.warn('Bet9ja scrape failed:', err.message);
+        return null;
+    }
+}
+
+app.get('/scrape', async (req, res) => {
+    console.log('📊 Scrape request received from:', req.get('origin'));
+    let matches = await fetchBet9jaMatches();
+    if (!matches || matches.length === 0) {
+        matches = [
+            {
+                match: 'Arsenal vs Chelsea',
+                time: '15:00',
+                markets: { '1': 2.10, 'X': 3.40, '2': 3.20, '1X': 1.35, '12': 1.25, 'X2': 1.80, 'Over 2.5': 1.75, 'Under 2.5': 2.05 }
+            },
+            {
+                match: 'Liverpool vs Manchester City',
+                time: '17:30',
+                markets: { '1': 2.80, 'X': 3.10, '2': 2.45, '1X': 1.50, '12': 1.35, 'X2': 1.40, 'Over 2.5': 1.60, 'Under 2.5': 2.25 }
+            },
+            {
+                match: 'Real Madrid vs Barcelona',
+                time: '20:00',
+                markets: { '1': 2.50, 'X': 3.20, '2': 2.90, '1X': 1.45, '12': 1.30, 'X2': 1.70, 'Over 2.5': 1.65, 'Under 2.5': 2.15 }
+            }
+        ];
+    }
+    res.json({
+        success: true,
+        matches,
+        timestamp: new Date().toISOString(),
+        source: matches && matches[0] && matches[0].markets ? 'bet9ja' : 'mock-testing-data',
+        message: '🎯 Data loaded successfully'
+    });
+});
+
+app.use((err, req, res, next) => {
+    console.error('Server error:', err);
+    res.status(500).json({ success: false, error: err.message });
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, '127.0.0.1', () => {
+    console.log('🚀 Backend server started successfully!');
+    console.log(`📍 Server URL: http://127.0.0.1:${PORT}`);
+    console.log(`🔗 Frontend URL: http://127.0.0.1:5500`);
+    console.log(`✅ Health check: http://127.0.0.1:${PORT}/health`);
+    console.log(`📊 Test scraper: http://127.0.0.1:${PORT}/scrape`);
+    console.log('');
+    console.log('💡 Ready to receive requests from your betting pipeline!');
+});


### PR DESCRIPTION
## Summary
- allow text-based match input and remove file loading
- add optional team info from Wikipedia during analysis
- document new workflow in README
- fix factorial to avoid recursion errors and validate parsed matches
- remove external team info lookup for reliability
- refine confidence scoring logic
- add custom match loading and fix probability calc
- add web match fetching
- clarify scraping server setup
- add a fallback Bet9ja scraper with environment variable

## Testing
- `npm install`
- `tidy -q -e index.html`


------
https://chatgpt.com/codex/tasks/task_e_684a88526208832f9ad6d8bcdffecce0